### PR TITLE
Show AlertDialog 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:name=".InterPrepApp"
         tools:targetApi="31">
         <activity
+            android:screenOrientation="portrait"
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.AppSplash">

--- a/app/src/main/kotlin/com/twain/interprep/domain/usecase/interview/GetInterviewsUseCase.kt
+++ b/app/src/main/kotlin/com/twain/interprep/domain/usecase/interview/GetInterviewsUseCase.kt
@@ -3,10 +3,9 @@ package com.twain.interprep.domain.usecase.interview
 import com.twain.interprep.data.model.Interview
 import com.twain.interprep.domain.repository.InterviewRepository
 import com.twain.interprep.utils.DateUtils
-import kotlinx.coroutines.flow.transform
 import java.util.Calendar
 import java.util.Date
-import java.util.Locale
+import kotlinx.coroutines.flow.transform
 
 class GetInterviewsUseCase(private val interviewRepository: InterviewRepository) {
 
@@ -19,9 +18,9 @@ class GetInterviewsUseCase(private val interviewRepository: InterviewRepository)
                     comingNextInterviews = mutableListOf(),
                     pastInterviews = mutableListOf()
                 )
-            if (interviews.isNotEmpty()) dashBoardInterviews.isEmptyInterviewList = false
+            dashBoardInterviews.isEmptyInterviewList = interviews.isEmpty()
             interviews.onEach { interview ->
-                val date = DateUtils.convertStringToDate(interview.date)
+                val date = DateUtils.convertDateTimeStringToDate(interview.date, interview.time)
 
                 if (date.before(Date())) {
                     dashBoardInterviews.pastInterviews.add(interview)
@@ -34,21 +33,21 @@ class GetInterviewsUseCase(private val interviewRepository: InterviewRepository)
             emit(dashBoardInterviews)
         }
 
-
+    /**
+     * @return true iff the given date is in the same week as the current week
+     */
     private fun isInterviewDateInSameWeek(date: Date): Boolean {
-        val currentDateTime = Calendar.getInstance(Locale.getDefault())
-        val interviewDateTime = Calendar.getInstance(Locale.getDefault())
+        val c: Calendar = Calendar.getInstance()
+        c.firstDayOfWeek = Calendar.MONDAY
+        c.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+        c.set(Calendar.HOUR_OF_DAY, 0)
+        c.set(Calendar.MINUTE, 0)
+        c.set(Calendar.SECOND, 0)
+        c.set(Calendar.MILLISECOND, 0)
 
-        currentDateTime.time = Date()
-        interviewDateTime.time = date
-
-        val currentWeek = currentDateTime.get(Calendar.WEEK_OF_YEAR)
-        val comparedWeek = interviewDateTime.get(Calendar.WEEK_OF_YEAR)
-
-        val currentYear = currentDateTime.get(Calendar.YEAR)
-        val comparedYear = interviewDateTime.get(Calendar.YEAR)
-
-        return currentWeek == comparedWeek && currentYear == comparedYear
+        val monday: Date = c.time
+        val nextMonday = Date(monday.time + 7 * 24 * 60 * 60 * 1000)
+        return date.after(monday) && date.before(nextMonday)
     }
 
     data class DashBoardInterviews(

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/IPDatePicker.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/IPDatePicker.kt
@@ -73,9 +73,9 @@ fun IPDatePicker(
         ) {
             DatePicker(
                 state = datePickerState,
-                dateValidator = { utcDateInMills ->
-                    isValidDate(utcDateInMills)
-                },
+//                dateValidator = { utcDateInMills ->
+//                    isValidDate(utcDateInMills)
+//                },
                 colors = DatePickerDefaults.colors(
                     selectedDayContainerColor = Purple200,
                     selectedDayContentColor = Color.Black

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/InterviewCard.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/InterviewCard.kt
@@ -86,7 +86,7 @@ fun InterviewCard(
                 .fillMaxSize()
                 .padding(dimensionResource(id = R.dimen.dimension_16dp))
         ) {
-            val date = DateUtils.convertStringToDate(interview.date)
+            val date = DateUtils.convertDateStringToDate(interview.date)
             Box(
                 //TODO change constant size value
                 modifier = Modifier
@@ -139,11 +139,8 @@ fun InterviewCard(
                     color = TextPrimary,
                     style = MaterialTheme.typography.bodyMedium
                 )
-                var roundRoleText = "N/A"
-                if(interview.roundNum.isNotEmpty() && interview.role.isNotEmpty())
-                    roundRoleText = "#${interview.roundNum} - ${interview.role}"
                 Text(
-                    text = roundRoleText,
+                    text = formatRoundNumAndInterviewType(interview),
                     color = textColor,
                     style = MaterialTheme.typography.bodyMedium,
                     overflow = TextOverflow.Ellipsis,
@@ -152,6 +149,26 @@ fun InterviewCard(
             }
         }
     }
+}
+/**
+ * Format the roundNum and interviewType of the given interview so that when roundNum is empty,
+ * only interviewType is shown which might be empty and when interviewType is empty, only
+ * roundNum is shown which might be empty. The result can only be one of the following
+ * "#${interview.roundNum}" or "${interview.interviewType}"
+ * or "#${interview.roundNum} - ${interview.interviewType}".
+ *
+ * @return the formatted string
+ */
+fun formatRoundNumAndInterviewType(interview: Interview): String{
+    val formattedRoundNum =
+        if (interview.roundNum.isNotEmpty())
+            "#${interview.roundNum} "
+        else ""
+    val formattedInterviewType =
+        if (interview.roundNum.isNotEmpty() && interview.interviewType.isNotEmpty())
+            "- ${interview.interviewType}"
+        else interview.interviewType
+    return formattedRoundNum + formattedInterviewType
 }
 
 @Composable

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/dashboard/AddInterviewScreen.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/dashboard/AddInterviewScreen.kt
@@ -2,6 +2,7 @@ package com.twain.interprep.presentation.ui.modules.dashboard
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
@@ -31,6 +35,7 @@ import com.twain.interprep.data.model.getInterviewField
 import com.twain.interprep.data.model.isValid
 import com.twain.interprep.data.ui.AddInterviewData.Companion.textTextInputHorizontalListAttributes
 import com.twain.interprep.data.ui.AddInterviewData.Companion.textTextInputVerticalListAttributes
+import com.twain.interprep.presentation.ui.components.IPAlertDialog
 import com.twain.interprep.presentation.ui.components.IPAppBar
 import com.twain.interprep.presentation.ui.components.IPHeader
 import com.twain.interprep.presentation.ui.components.IPTextInput
@@ -41,6 +46,12 @@ fun AddInterviewScreen(
     navController: NavHostController,
     viewModel: InterviewViewModel = hiltViewModel()
 ) {
+    val showDialog = remember { mutableStateOf(false) }
+
+    // this ms controls if we should highlight any empty mandatory input field
+    // by showing an error message
+    val shouldValidate = remember { mutableStateOf(false) }
+
     LaunchedEffect(Unit) {
         viewModel.interviewData = Interview()
     }
@@ -57,16 +68,33 @@ fun AddInterviewScreen(
         topBar = {
             IPAppBar(stringResource(id = R.string.appbar_title_add_interview)) {
                 IconButton(onClick = {
-                    if (viewModel.interviewData.isValid())
+                    if (viewModel.interviewData.isValid()) {
                         viewModel.insertInterview(viewModel.interviewData)
-
-                    navController.popBackStack()
+                        navController.popBackStack()
+                    } else {
+                        showDialog.value = true
+                    }
                 }) {
                     Icon(Icons.Filled.ArrowBack, null, tint = Color.White)
                 }
             }
         },
         content = { padding ->
+            if (showDialog.value) {
+                IPAlertDialog(
+                    titleResId = R.string.alert_dialog_unsaved_interview_title,
+                    contentResId = R.string.alert_dialog_unsaved_interview_text,
+                    onPositiveButtonClick = {
+                        showDialog.value = false
+                        navController.popBackStack()
+                    }, // "OK" is clicked
+                    onNegativeButtonClick = {
+                        showDialog.value = false
+                        shouldValidate.value = true
+                    } // "CANCEL" is clicked
+                )
+            }
+
             Column(
                 modifier = Modifier
                     .padding(padding)
@@ -94,6 +122,7 @@ fun AddInterviewScreen(
                                 .weight(1f),
                             inputText = viewModel.interviewData.getInterviewField(input.labelTextId),
                             textInputAttributes = input,
+                            shouldValidate = shouldValidate.value,
                             onTextUpdate = {
                                 viewModel.updateInterviewField(input.labelTextId, it)
                             }
@@ -105,6 +134,7 @@ fun AddInterviewScreen(
                         modifier = Modifier.fillMaxWidth(),
                         inputText = viewModel.interviewData.getInterviewField(input.labelTextId),
                         textInputAttributes = input,
+                        shouldValidate = shouldValidate.value,
                         onTextUpdate = {
                             viewModel.updateInterviewField(input.labelTextId, it)
                         }

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/dashboard/DashboardScreen.kt
@@ -60,11 +60,11 @@ fun DashboardScreen(
         content = { padding ->
             if (viewModel.interviews is ViewResult.Loaded) {
                 val interviews = viewModel.interviews as ViewResult.Loaded
-                if (interviews.data.isEmptyInterviewList)
+                if (interviews.data.isEmptyInterviewList) {
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                    )  {
+                    ) {
                         FullScreenEmptyState(
                             Modifier,
                             R.drawable.empty_state_dashboard,
@@ -72,6 +72,8 @@ fun DashboardScreen(
                             stringResource(id = R.string.empty_state_description_dashboard)
                         )
                     }
+                }
+
                 LazyColumn(
                     modifier = Modifier.padding(padding),
                     contentPadding = PaddingValues(dimensionResource(id = R.dimen.dimension_8dp))

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/interview/InterviewViewModel.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/interview/InterviewViewModel.kt
@@ -1,8 +1,10 @@
 package com.twain.interprep.presentation.ui.modules.interview
 
 import androidx.annotation.StringRes
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.twain.interprep.R
 import com.twain.interprep.data.model.Interview

--- a/app/src/main/kotlin/com/twain/interprep/utils/DateUtils.kt
+++ b/app/src/main/kotlin/com/twain/interprep/utils/DateUtils.kt
@@ -3,6 +3,7 @@ package com.twain.interprep.utils
 import android.icu.text.SimpleDateFormat
 import android.icu.util.Calendar
 import android.icu.util.TimeZone
+import com.twain.interprep.constants.StringConstants.Companion.DT_FORMAT_HOUR_MIN
 import com.twain.interprep.constants.StringConstants.Companion.DT_FORMAT_MM_DD_YYYY
 import java.util.Date
 import java.util.Locale
@@ -15,9 +16,17 @@ class DateUtils {
             return date?.time ?: 0L
         }
 
-        fun convertStringToDate(dateString: String): Date {
+        fun convertDateStringToDate(dateString: String): Date {
             val format = SimpleDateFormat(DT_FORMAT_MM_DD_YYYY, Locale.getDefault())
             return format.parse(dateString)
+        }
+
+        fun convertDateTimeStringToDate(dateString: String, timeString: String): Date {
+            val format = SimpleDateFormat(
+                "$DT_FORMAT_MM_DD_YYYY $DT_FORMAT_HOUR_MIN",
+                Locale.getDefault()
+            )
+            return format.parse("$dateString $timeString")
         }
 
         fun getCurrentDateAsString(): String {


### PR DESCRIPTION
# Tasks finished
1. fix the problem in GetInterviewsUseCase
2. highlight unfinished fields in the add interview screen when “cancel” is clicked
3. move the showDialog mutableState back to the addInterview composable and show the alertDialog once any of the mandatory fields is empty
4. Show RoundNum and interviewType only when they are given 

# Tests
1. Test GetInterviewsUseCase:  system time is set to December 30th, 3:12 PM

https://github.com/Audienix/InterPrep/assets/67870437/03c967e9-eee5-4ed5-b10e-ddda7a56fe76

https://github.com/Audienix/InterPrep/assets/67870437/0cd58036-9742-4c5e-b469-1eb54c49c493

2. Test highlights and alertDialog

https://github.com/Audienix/InterPrep/assets/67870437/eda97e19-f027-4847-8dd1-c3bf55266b09


3. Test RoundNum and interviewType

https://github.com/Audienix/InterPrep/assets/67870437/1e40b2a3-491b-4492-a3a2-63dbb091a613

https://github.com/Audienix/InterPrep/assets/67870437/3db3adf9-b886-44c8-aee2-1a09198efd5a



# Unresolved problem
The input composable have no idea of text change when showing the red error message. In the example below, the time input should remove the error message once the input changes.


https://github.com/Audienix/InterPrep/assets/67870437/61868e31-ad20-44f9-a478-7bcaea2ee054

