### PR TITLE
Changes to NotesCard, NotesScreen and AddNotesScreen

### DIFF
--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/note/InterviewDetailForNote.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/note/InterviewDetailForNote.kt
@@ -21,10 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.twain.interprep.R
@@ -33,6 +29,11 @@ import com.twain.interprep.presentation.ui.components.generic.DateTimeBox
 import com.twain.interprep.presentation.ui.components.interview.interviewMockData
 import com.twain.interprep.presentation.ui.theme.BackgroundDarkPurple
 import com.twain.interprep.utils.DateUtils
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import com.twain.interprep.presentation.ui.components.interview.formatRoundNumAndInterviewType
 
 @Composable
 fun InterviewDetailForNote(
@@ -44,23 +45,13 @@ fun InterviewDetailForNote(
             val date = DateUtils.convertDateStringToDate(interview.date)
             DateTimeBox(borderColor = BackgroundDarkPurple, date = date)
         }
-        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.dimension_8dp)))
-        Box(modifier = Modifier.height(80.dp)) {
-            Column(modifier = Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
-                Text(
-                    text = interview.company,
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    buildAnnotatedString {
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append("#${interview.roundNum}")
-                        }
-                        append(" - ${interview.interviewType}")
-                    }
-                )
-            }
-        }
+        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.dimension_16dp)))
+        InterviewDetails(
+            interview = interview,
+            companyTextColor = Color.Black,
+            roundTypeTextColor = Color.Gray,
+            height = 80.dp
+        )
         Box(modifier = Modifier.fillMaxWidth()) {
             IconButton(modifier = Modifier.align(Alignment.TopEnd), onClick = { /*TODO*/ }) {
                 Icon(
@@ -68,6 +59,35 @@ fun InterviewDetailForNote(
                     contentDescription = stringResource(id = R.string.icon_more_vert_content_description)
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun InterviewDetails(
+    height: Dp,
+    interview: Interview,
+    companyTextColor: Color,
+    companyTextStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    roundTypeTextColor: Color,
+    roundTypeTextStyle: TextStyle = MaterialTheme.typography.bodyMedium) {
+    Box(modifier = Modifier.height(height)) {
+        Column(
+            modifier = Modifier.fillMaxHeight(),
+            verticalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Text(
+                text = interview.company,
+                color = companyTextColor,
+                style =companyTextStyle
+            )
+            Text(
+                text = formatRoundNumAndInterviewType(interview),
+                color = roundTypeTextColor,
+                style = roundTypeTextStyle,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/note/NoteCard.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/note/NoteCard.kt
@@ -93,10 +93,12 @@ fun NoteCard(
                                 text = note.interviewSegment,
                                 style = MaterialTheme.typography.bodyLarge
                             )
-                            Text(
-                                text = note.topic,
-                                style = MaterialTheme.typography.bodyMedium
-                            )
+                            if (note.topic.isNotEmpty()) {
+                                Text(
+                                    text = note.topic,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
                             note.questions.forEach {
                                 Text(
                                     text = it,
@@ -111,7 +113,8 @@ fun NoteCard(
                 horizontalArrangement = Arrangement.End,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = dimensionResource(id = R.dimen.dimension_24dp))
+                    .padding(horizontal = dimensionResource(id = R.dimen.dimension_8dp),
+                        vertical = dimensionResource(id = R.dimen.dimension_24dp))
             ) {
                 IPFilledButton(
                     backgroundColor = BackgroundDarkPurple,

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/note/NoteCard.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/note/NoteCard.kt
@@ -65,47 +65,43 @@ fun NoteCard(
                     interview = interview
                 )
             }
-            if (notes.isNotEmpty()) {
+            notes.firstOrNull()?.let { note ->
                 Divider()
-                notes.forEachIndexed { index, note ->
-                    Row(
+                Row(
+                    modifier = Modifier
+                        .padding(top = dimensionResource(id = R.dimen.dimension_16dp))
+                        .clickable { onDeleteNoteClick(note) }
+                ) {
+                    Box(
                         modifier = Modifier
-                            .padding(top = dimensionResource(id = R.dimen.dimension_16dp))
-                            .clickable { onDeleteNoteClick(note) }
+                            .size(dimensionResource(id = R.dimen.dimension_32dp))
+                            .clip(CircleShape)
+                            .background(Purple100),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Box(
-                            modifier = Modifier
-                                .size(dimensionResource(id = R.dimen.dimension_32dp))
-                                .clip(CircleShape)
-                                .background(Purple100),
-                            contentAlignment = Alignment.Center
-                        ) {
+                        Text(
+                            text = "1",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.dimension_8dp)))
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.dimension_4dp))
+                    ) {
+                        Text(
+                            text = note.interviewSegment,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        if (note.topic.isNotEmpty()) {
                             Text(
-                                text = index.toString(),
-                                style = MaterialTheme.typography.titleMedium
+                                text = note.topic,
+                                style = MaterialTheme.typography.bodyMedium
                             )
                         }
-                        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.dimension_8dp)))
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.dimension_4dp))
-                        ) {
-                            Text(
-                                text = note.interviewSegment,
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-                            if (note.topic.isNotEmpty()) {
-                                Text(
-                                    text = note.topic,
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            }
-                            note.questions.forEach {
-                                Text(
-                                    text = it,
-                                    style = MaterialTheme.typography.bodySmall
-                                )
-                            }
-                        }
+                        Text(
+                            text = note.questions.firstOrNull().orEmpty(),
+                            style = MaterialTheme.typography.bodySmall
+                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/notes/AddNotesScreen.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/notes/AddNotesScreen.kt
@@ -54,7 +54,7 @@ fun AddNotesScreen(
                 .background(MaterialTheme.colorScheme.background),
             topBar = {
                 IPAppBar(
-                    title = stringResource(id = R.string.appbar_title_interview_details),
+                    title = stringResource(id = R.string.appbar_header_add_notes),
                     navIcon = {
                         IconButton(onClick = {
                             navController.popBackStack()

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/notes/AddNotesScreen.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/notes/AddNotesScreen.kt
@@ -28,7 +28,6 @@ import androidx.navigation.NavController
 import com.twain.interprep.R
 import com.twain.interprep.data.model.Interview
 import com.twain.interprep.data.model.ViewResult
-import com.twain.interprep.presentation.ui.components.generic.DeleteIcon
 import com.twain.interprep.presentation.ui.components.generic.IPAppBar
 import com.twain.interprep.presentation.ui.components.generic.IPHeader
 import com.twain.interprep.presentation.ui.components.generic.IPOutlinedButton
@@ -63,9 +62,7 @@ fun AddNotesScreen(
                             Icon(Icons.Filled.ArrowBack, null, tint = Color.White)
                         }
                     }
-                ) {
-                    DeleteIcon { }
-                }
+                )
             },
             content = { padding ->
                 Column(
@@ -96,7 +93,11 @@ fun AddNotesScreen(
                     viewModel.notes.forEachIndexed { index, note ->
                         AddNoteCard(
                             modifier = Modifier
-                            .padding(horizontal = dimensionResource(id = R.dimen.dimension_16dp))
+                            .padding(
+                                start = dimensionResource(id = R.dimen.dimension_12dp),
+                                end = dimensionResource(id = R.dimen.dimension_12dp),
+                                top = dimensionResource(id = R.dimen.dimension_16dp)
+                            )
                             .fillMaxWidth(),
                             note = note,
                             getNoteField = { viewModel.getNoteField(it, index) },

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/notes/NotesScreen.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/modules/notes/NotesScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,20 +52,22 @@ fun NotesScreen(
                 )
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.dimension_8dp)))
-            interviewNotePairs.forEach { (interview, notes) ->
-                NoteCard(
-                    interviewNotePair = interview to notes,
-                    onDeleteNoteClick = {
-                        viewModel.deleteNote(interview, it)
-                    },
-                    onViewNoteClick = {
-                    },
-                    onAddNoteClick = {
-                        navController.navigate(AppScreens.AddNotes.withArgs(interview.interviewId)) {
-                            popUpTo(AppScreens.Notes.route)
+            LazyColumn {
+                items(interviewNotePairs) { (interview, notes) ->
+                    NoteCard(
+                        interviewNotePair = interview to notes,
+                        onDeleteNoteClick = {
+                            viewModel.deleteNote(interview, it)
+                        },
+                        onViewNoteClick = {
+                        },
+                        onAddNoteClick = {
+                            navController.navigate(AppScreens.AddNotes.withArgs(interview.interviewId)) {
+                                popUpTo(AppScreens.Notes.route)
+                            }
                         }
-                    }
-                )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="add_note_header">Add your interview notes</string>
     <string name="add_note_question">Add Question</string>
     <string name="add_note">Add Note</string>
+    <string name="appbar_header_add_notes">Add Notes</string>
 
     <string name="hint_label_interview_segment">Interview Segment</string>
     <string name="hint_label_topic">Topic</string>


### PR DESCRIPTION
### Changes made
1. Made NotesScreen into a lazy list
2. Removed delete icon from app bar in AddNotesScreen
3. Added padding to NotesCard
4. Recovered changes from [this PR](https://github.com/Audienix/InterPrep/pull/21) that were lost in `development` (ie. refactoring of InterviewDetailCard, showing only one note under the NoteCard in NotesScreen)