### PR TITLE
Interview repository tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,4 +101,8 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+
+    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    testImplementation("org.mockito:mockito-inline:2.8.47")
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
 }

--- a/app/src/main/kotlin/com/twain/interprep/utils/DateUtils.kt
+++ b/app/src/main/kotlin/com/twain/interprep/utils/DateUtils.kt
@@ -41,6 +41,7 @@ object DateUtils {
         return format.format(Calendar.getInstance().time)
     }
 
+    @JvmStatic
     fun getCurrentDateTimeAsString() : String {
         // Get the current time
         val currentTime = Calendar.getInstance().time
@@ -55,6 +56,8 @@ object DateUtils {
         val dateFormat = SimpleDateFormat(DT_FORMAT_MM_DD_YYYY_HH_MM_NO_SPACE, Locale.getDefault())
         return dateFormat.format(calendar.time)
     }
+
+    @JvmStatic
     fun getWeekAfterCurrentDateAsString(): String {
         val timeString = getCurrentDateTimeAsString()
         val format = SimpleDateFormat(DT_FORMAT_MM_DD_YYYY_HH_MM_NO_SPACE, Locale.getDefault())

--- a/app/src/test/kotlin/com/twain/interprep/InterviewRepositoryTests.kt
+++ b/app/src/test/kotlin/com/twain/interprep/InterviewRepositoryTests.kt
@@ -1,0 +1,113 @@
+package com.twain.interprep
+
+import com.twain.interprep.data.dao.InterviewDAO
+import com.twain.interprep.data.model.Interview
+import com.twain.interprep.data.model.InterviewList
+import com.twain.interprep.data.model.InterviewListMetaData
+import com.twain.interprep.data.model.InterviewType
+import com.twain.interprep.data.repository.InterviewRepositoryImpl
+import com.twain.interprep.domain.repository.InterviewRepository
+import com.twain.interprep.utils.DateUtils
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class InterviewRepositoryTests {
+
+    private lateinit var interviewRepository: InterviewRepository
+    private lateinit var interviewDao: InterviewDAO
+    private lateinit var dateUtils: MockedStatic<DateUtils>
+
+    @Before
+    fun setup() {
+        interviewDao = mock()
+        interviewRepository = InterviewRepositoryImpl(interviewDao)
+        dateUtils = mockStatic(DateUtils::class.java)
+        dateUtils.`when`<String>(DateUtils::getCurrentDateTimeAsString).thenReturn("placeholder")
+        dateUtils.`when`<String>(DateUtils::getWeekAfterCurrentDateAsString).thenReturn("placeholder")
+
+        // mock DAO results
+        whenever(interviewDao.getPastInterviews(any(), any(), any())).thenReturn(
+            flow { emit(PAST_INTERVIEWS) }
+        )
+        whenever(interviewDao.getUpcomingInterviews(any(), any(), any(), any())).thenReturn(
+            flow { emit(UPCOMING_INTERVIEWS) }
+        )
+        whenever(interviewDao.getComingNextInterviews(any(), any(), any())).thenReturn(
+            flow { emit(COMING_NEXT_INTERVIEWS) }
+        )
+        whenever(interviewDao.getInterview(1)).thenReturn(
+            flow { emit(PAST_INTERVIEW_1) }
+        )
+    }
+
+    @Test
+    fun testGetInitialInterviews() = runBlocking {
+        val expected = InterviewListMetaData(
+            pastInterviewList = InterviewList(PAST_INTERVIEWS, 0, false),
+            upcomingInterviewList = InterviewList(UPCOMING_INTERVIEWS, 0, false),
+            comingNextInterviewList = InterviewList(COMING_NEXT_INTERVIEWS, 0, false)
+
+        )
+        val actual = interviewRepository.getInitialInterviews().single()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testGetPastInterviews() = runBlocking {
+        val expected = PAST_INTERVIEWS
+        val actual = interviewRepository.getInterviewList(InterviewType.PAST, 0).single()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testGetUpcomingInterviews() = runBlocking {
+        val expected = UPCOMING_INTERVIEWS
+        val actual = interviewRepository.getInterviewList(InterviewType.UPCOMING, 0).single()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testGetComingNextInterviews() = runBlocking {
+        val expected = COMING_NEXT_INTERVIEWS
+        val actual = interviewRepository.getInterviewList(InterviewType.COMING_NEXT, 0).single()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testGetInterviewById() = runBlocking {
+        val expected = PAST_INTERVIEW_1
+        val actual = interviewRepository.getInterviewById(1).single()
+        assertEquals(expected, actual)
+    }
+
+    @After
+    fun cleanup() {
+        dateUtils.close()
+    }
+
+    companion object {
+        private val PAST_INTERVIEW_1 = Interview(1, "past1", "past1")
+        private val PAST_INTERVIEW_2 = Interview(2, "past2", "past2")
+        private val UPCOMING_INTERVIEW_1 = Interview(3, "upcoming1", "upcoming1")
+        private val UPCOMING_INTERVIEW_2 = Interview(4, "upcoming2", "upcoming2")
+        private val COMING_NEXT_INTERVIEW_1 = Interview(5, "comingNext1", "comingNext1")
+        private val COMING_NEXT_INTERVIEW_2 = Interview(6, "comingNext2", "comingNext2")
+
+        private val PAST_INTERVIEWS = listOf(PAST_INTERVIEW_1, PAST_INTERVIEW_2)
+        private val UPCOMING_INTERVIEWS = listOf(UPCOMING_INTERVIEW_1, UPCOMING_INTERVIEW_2)
+        private val COMING_NEXT_INTERVIEWS = listOf(COMING_NEXT_INTERVIEW_1, COMING_NEXT_INTERVIEW_2)
+    }
+}


### PR DESCRIPTION
Notes:
1. This PR only tests GET functions - insert, update and delete functions seems only possible at the DAO tests
2. See the first point at my learnings, is there any particular uses for `@JvmStatic` other than the test scenarios? I see this in many places at Wattpad code but does not know why are they added because I believe they are static already.

Learnings:
1. The DateUtils is an `object`, to mock an object using Mockito we need to use Mockito.mockStatic and must add the annotation `@JvmStatic` to the tested methods
3. We need to close `mockStatic` when we finish the tests - otherwise it will throw the following exception: 

`For com.twain.interprep.utils.DateUtils, static mocking is already registered in the current thread
To create a new mock, the existing static mock registration must be deregistered
org.mockito.exceptions.base.MockitoException: 
For com.twain.interprep.utils.DateUtils, static mocking is already registered in the current thread
To create a new mock, the existing static mock registration must be deregistered
at app//com.twain.interprep.InterviewRepositoryTests.setup(InterviewRepositoryTests.kt:37)`