### PR TITLE
Fix link text position in the TodayInterviewCard

### DIFF
--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/generic/IPLargeAppBar.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/generic/IPLargeAppBar.kt
@@ -56,7 +56,7 @@ fun IPLargeAppBar(
     subtitle: String,
     todayInterviewList: List<Interview>,
     username: String,
-    isInterviewDetailsVisible: Boolean = false,
+    isInterviewDetailsVisible: Boolean,
     navController: NavHostController,
     onAvatarClick: () -> Unit
 ) {
@@ -69,7 +69,7 @@ fun IPLargeAppBar(
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.dimension_4dp))
     ) {
-        GreetingsAndProfile(title, username, subtitle, onAvatarClick)
+        GreetingsAndProfile(title, username, if(isInterviewDetailsVisible)subtitle else "", onAvatarClick)
         if (isInterviewDetailsVisible) {
             if (todayInterviewList.isEmpty())
                 NoInterviewTodayDetails()
@@ -116,14 +116,16 @@ private fun GreetingsAndProfile(
             textColor = MaterialColorPalette.onTertiary,
         )
     }
-    Text(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = dimensionResource(id = R.dimen.dimension_16dp)),
-        text = subtitle,
-        style = MaterialTheme.typography.bodyLarge,
-        color = MaterialColorPalette.onSurfaceVariant
-    )
+    if(subtitle.isNotEmpty()) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = R.dimen.dimension_16dp)),
+            text = subtitle,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialColorPalette.onSurfaceVariant
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/generic/IPLargeAppBar.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/generic/IPLargeAppBar.kt
@@ -308,7 +308,10 @@ fun TodayInterviewCard(
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }
-                    if(interview.meetingLink.isNotEmpty()) {
+                }
+
+                if(interview.meetingLink.isNotEmpty()) {
+                    Box(modifier = Modifier.fillMaxWidth()) {
                         IPText(
                             modifier = Modifier
                                 .align(Alignment.CenterEnd)


### PR DESCRIPTION
### Issue
The position of the link text overlaps with the interview time, which causing a visual conflict.

<img width="217" alt="Screenshot 2023-11-08 at 12 50 39 AM" src="https://github.com/Audienix/InterPrep/assets/144148115/f2147418-c66e-4840-b8aa-14bc168e5653">

### Type of Change(s)
<!-- What type of changes does this PR introduce ? Put an `x` in all the boxes that apply. -->
- [x] Bug Fix
- [] New Feature
- [ ] Documentation
- [ ] Code Refactoring
- [ ] Kotlin Conversion
- [ ] Script Improvement
- [ ] Other: Please elaborate.

### How have I tested this ?
<!-- Provide instructions on how you have tested this change. Put an `x` in all the boxes that apply. -->
- [x] Manual Testing
- [ ] Unit Testing
- [ ] Other: Please elaborate

### Screenshot
<img width="337" alt="Screenshot 2023-11-08 at 12 52 05 AM" src="https://github.com/Audienix/InterPrep/assets/144148115/729f91f6-8fae-487b-a50e-8139e5da3288">



### Known Issues
NA

### Clean Delivery Checklist
<!-- It's not mandatory to check off all items on this list, Check only the conditions this PR meets
or that applies. This will help us track our progress towards clean delivery. -->
- [x] User interfaces are accessibility-enabled
- [x] No commented out code.
- [x] No IDE warnings in new files
- [x] No Detekt & Ktlint error.
- [ ] Unit tests for new code (for everything listed in [what we test](../blob/master/docs/best-practices/unit-tests.md#what-do-we-test))