### PR TITLE
remove duplicated meetingLink

### DIFF
--- a/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/generic/IPLargeAppBar.kt
+++ b/app/src/main/kotlin/com/twain/interprep/presentation/ui/components/generic/IPLargeAppBar.kt
@@ -370,17 +370,6 @@ fun TodayInterviewCard(
                             interview.time
                         ))
                     }
-                    if (interview.meetingLink.isNotEmpty()) {
-                        IPText(
-                            modifier = Modifier
-                                .align(Alignment.CenterEnd)
-                                .wrapContentWidth(),
-                            text = stringResource(id = R.string.label_join_here),
-                            link = interview.meetingLink,
-                            textColor = MaterialColorPalette.onPrimary,
-                            textStyle = MaterialTheme.typography.bodyLarge,
-                        )
-                    }
                 }
 
                 // second row


### PR DESCRIPTION
### Issue
The position of the link text overlaps with the interview time, which causing a visual conflict.

### Type of Change(s)
<!-- What type of changes does this PR introduce ? Put an `x` in all the boxes that apply. -->
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Code Refactoring
- [ ] Kotlin Conversion
- [ ] Script Improvement
- [ ] Other: Please elaborate.

### How have I tested this ?
<!-- Provide instructions on how you have tested this change. Put an `x` in all the boxes that apply. -->
- [x] Manual Testing
- [ ] Unit Testing
- [ ] Other: Please elaborate

### Screenshots
before fixed
![screenshot_20240319_015407_interprep_720](https://github.com/Audienix/InterPrep/assets/144148115/99e04143-3923-46ab-b98a-c6a390e16deb)

after fixed
![screenshot_20240319_021111_interprep_720](https://github.com/Audienix/InterPrep/assets/144148115/e3a94da3-f61b-49d1-82b7-da0efc42db12)


### Known Issues
NA

### Clean Delivery Checklist
<!-- It's not mandatory to check off all items on this list, Check only the conditions this PR meets
or that applies. This will help us track our progress towards clean delivery. -->
- [ ] User interfaces are accessibility-enabled
- [x] No commented out code.
- [x] No IDE warnings in new files
- [x] No Detekt & Ktlint error.
- [ ] Unit tests for new code (for everything listed in [what we test](../blob/master/docs/best-practices/unit-tests.md#what-do-we-test))